### PR TITLE
Update intro to CONTRIBUTING.md for easier onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,8 @@
 # How to contribute
 
-I'm really glad you're reading this, because we need active developers to help this project come to fruition.
-We're establishing a community process for contributors to earn RHOC working for the coop. See video [24:06 HJ explains Members Decentralized Budgeting](https://www.youtube.com/watch?v=7Li4g4qDF6M&t=1486s) and video [RChain, Decentralized budgeting and spending](https://www.youtube.com/watch?v=m6xiTWbEdpA).
+*New here? Before you go any further, read this: [Welcome to the Bounty Program](https://github.com/rchain/bounties/wiki/Welcome-to-the-Bounty-Program).*
 
-Everyone is welcome to participate. Contributing doesn’t just mean coding; there are many different ways for you to get involved, including community activism, marketing, business development, design, and governance.
+We're really glad you're here, because we need active contributing members to help this project come to fruition. We've established a community process for contributors to earn RHOC working for the coop, and everyone is welcome to participate. Contributing doesn’t just mean coding; there are many different ways for you to get involved, including community activism, marketing, business development, design, and governance.
 
 ### Communication
 


### PR DESCRIPTION
Added a link to the wiki page that finally helped me understand more about how this all works. I also removed the redundant link to the budgeting video from the top (it's still there further down the page). If you watch those videos before you know what's going on (like I did), you'll just be super, super confused.

This contributing page was the first thing I was pointed to by several members of the community, and I was still extremely confused until I stumbled upon that wiki page. Hopefully this will help future members with their onboarding process.