### PR TITLE
prune misleading translation checklist

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -18,27 +18,3 @@ _How will we measure completion?_ **[example: pull request merged]**
 ### Legal
 
 _Task Submitter shall not submit Tasks that will involve RHOC being transacted in any manner that (i) jeopardizes RHOC’s status as a software access token or other relevant and applicable description of the RHOC as an “asset”—not a security— or (2) violates, in any manner, applicable U.S. Securities laws._
-
-### Translation Checklist
-
-*for non translation issues, delete this section*
-
-  - Why translate this document?
-    - It's important to translate because ____
-    - [ ] It's an RChain blog item on [Medium](https://medium.com/rchain-cooperative)
-    - [ ] It's an RChain blog item on https://blog.rchain.coop/
-    - [ ] It's a document on https://developer.rchain.coop/ that has been endorsed
-          for translation by @Jake-Gillberg, @MParlikar, or @KellyAtPyrofex 
-  - How can people who do not speak this language be assured of the quality of the translation? (all are required)
-    - [ ] several reviewers are involved (_assign the ticket to them_)
-    - [ ] at least two of them have high proficiency in _the target language_
-    - [ ] at least two of them have high proficiency in English
-    - [ ] at least two of them have either
-       - [ ] formal training: degree / certificate: ___ from institution: _____
-       - [ ] a track record of quality work on rchain bounties: #nn, #nn, ...
-       - [ ] another body of work readily available for community review: _____
-  - What about maintenance? (choose one)
-    - [ ] the source document is stable; further translation work is not expected
-    - [ ] our plan to keep the translation up to date is: ____
-
-_**Word counting and pricing for translations will be done with [The World's Fastest Human Translation Service](https://customer.stepes.com/instant-translation-quote/#)**_


### PR DESCRIPTION
The checklist was introduced to put a lower bound on acceptable translation work, but it seems to give the impression that translation work is especially invited, or even that any work that addresses all the items on the checklist is automatically rewarded.

The checklist remains available in the git history; I also copied the content to a https://github.com/rchain/bounties/wiki/Translation-Checklist wiki page, along with a link to issue #483.

cc @AyAyRon-P @pavlos1851 @allancto @ICA3DaR5 