### PR TITLE
Bounty info links are all screwif.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -25,7 +25,8 @@ _Task Submitter shall not submit Tasks that will involve RHOC being transacted i
 
   - Why translate this document?
     - It's important to translate because ____
-    - [ ] It's an [RChain blog](https://medium.com/rchain-cooperative) item
+    - [ ] It's an RChain blog item on [Medium](https://medium.com/rchain-cooperative)
+    - [ ] It's an RChain blog item on https://blog.rchain.coop/
     - [ ] It's a document on https://developer.rchain.coop/ that has been endorsed
           for translation by @Jake-Gillberg, @MParlikar, or @KellyAtPyrofex 
   - How can people who do not speak this language be assured of the quality of the translation? (all are required)


### PR DESCRIPTION
For the sake of the blog, the bounty system should be fully de-fluffed first. That way, the blog can lead developers to the bounties, not the other way around.